### PR TITLE
ci: Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   TF_CLOUD_ORGANIZATION: "Grupo-G03-4SOAT-FIAP"


### PR DESCRIPTION
Pessoal, eu incluí o trigger `workflow_dispatch` no CD para que a gente possa acionar o deploy tmb manualmente, pela interface do GitHub, caso a gente queira. 

Com isso vai aparecer um botão como esse abaixo na aba `Actions` pra que a gente possa rodar o workflows de deploy a qualquer momento, sem necessariamente precisar abrir e aprovar uma PR pra branch main. O deploy automático após aprovação de PRs continua funcionando normalmente.

![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/28d22484-a31b-4f33-875a-e2c7205cbf4c)

Fiquem tranquilos, só quem faz parte da organização consegue acionar o deploy manualmente.

Documentação do "workflow_dispatch" em https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch